### PR TITLE
TextField component allows multiline edit.

### DIFF
--- a/app/client/src/components/EditModal/EditCareerModal.js
+++ b/app/client/src/components/EditModal/EditCareerModal.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 import MaterialTable from 'material-table';
+import TextField from '@material-ui/core/TextField';
 
 const useStyles = makeStyles(theme => ({
     paper: {
@@ -55,7 +56,7 @@ const processData = (data, ignoreKeys) => {
 
         let row = {
             key: member,
-            value: data[member],
+            value: data[member],          
         }
 
         rows.push(row)
@@ -69,7 +70,17 @@ export default function EditModal(props) {
   
     const [columns] = useState([
         { title: 'Key', field: 'key', editable: 'never' },
-        { title: 'Value', field: 'value' },
+        { title: 'Value',
+          field: 'value',
+          editComponent: props => (
+            <TextField
+            id="standard-multiline-flexible"
+            multiline
+            fullWidth={true}
+            rowsMax={2}
+            value={props.value}
+            onChange={e => props.onChange(e.target.value)}
+          />)   },
     ]);
     const [state, setState] = useState({});
     const [modalStyle] = useState(getModalStyle);

--- a/app/client/src/components/EditModal/EditModal.js
+++ b/app/client/src/components/EditModal/EditModal.js
@@ -2,6 +2,8 @@ import React, {useState, useEffect} from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Modal from '@material-ui/core/Modal';
 import MaterialTable from 'material-table';
+import { text } from 'body-parser';
+import TextField from '@material-ui/core/TextField';
 
 const useStyles = makeStyles(theme => ({
     paper: {
@@ -41,6 +43,20 @@ const getColumns = (data, ignoreKeys) => {
         let column = {
             title: member,
             field: member,
+            editComponent: props => (
+                //<input
+                //  type="text"
+                //  value={props.value}
+                //  onChange={e => props.onChange(e.target.value)}
+                ///>)
+                <TextField
+                id="standard-multiline-flexible"
+                multiline
+                fullWidth={true}                
+                rowsMax={2}
+                value={props.value}
+                onChange={e => props.onChange(e.target.value)}
+              />)                          
         }
         columns.push(column)
     }
@@ -129,7 +145,7 @@ export default function EditModal(props) {
                                 });
                                 }, 600);
                             }),
-                    }}
+                    }}                  
                 />
             </div>
         </Modal>


### PR DESCRIPTION
Added TextField component override of material-table default input fields to EditModal.js and EditCareerModal.js . This was mainly for short description, description, DITL, and celebrity.article fields that were difficult to edit using the default input element.